### PR TITLE
adding important aero_state features

### DIFF
--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -210,8 +210,6 @@ module PyPartMC_aero_state
     call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
     call c_f_pointer(env_state_ptr_c, env_state_ptr_f)
 
-    print*, 'temperature', env_state_ptr_f%temp
-
     crit_rel_humids = aero_state_crit_rel_humids(ptr_f, aero_data_ptr_f, &
          env_state_ptr_f)
 
@@ -233,7 +231,6 @@ module PyPartMC_aero_state
 
     call aero_state_mixing_state_metrics(ptr_f, aero_data_ptr_f, d_alpha, &
          d_gamma, chi)
-    print*, d_alpha, d_gamma, chi
 
   end subroutine
 

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -30,8 +30,18 @@ module PyPartMC_aero_state
   subroutine f_aero_state_init(ptr_c, n_part, aero_data_ptr_c) bind(C)
     type(aero_state_t), pointer :: ptr_f => null()
     type(aero_data_t), pointer :: aero_data_ptr_f => null()
-    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    type(c_ptr) :: ptr_c, aero_data_ptr_c
     real(c_double), intent(in) :: n_part
+
+    ! local testing
+    type(aero_dist_t) :: aero_dist_init
+    real(kind=dp), parameter, dimension(2) :: num_conc = &
+         [3.2d9, 2.9d9]
+    real(kind=dp), parameter, dimension(2) :: diams = [2d-8, 1.16d-7]
+    real(kind=dp), parameter, dimension(2) :: std = [1.45,1.65]
+    character(len=10), parameter, dimension(2) :: mode_names = ["init_small","init_large"]
+    integer :: n_spec, n_modes, i_mode, i_water
+    integer :: n_part_added, source
 
     call c_f_pointer(ptr_c, ptr_f)
     call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
@@ -39,11 +49,34 @@ module PyPartMC_aero_state
     call aero_state_zero(ptr_f)
     call aero_state_set_weight(ptr_f, aero_data_ptr_f, AERO_STATE_WEIGHT_FLAT)
     call aero_state_set_n_part_ideal(ptr_f, n_part)
-    !call aero_state_add_aero_dist_sample(aero_state, aero_data_ptr_f, &
-    !       aero_dist_init, 1d0, 0d0, &
-    !       .false. & ! TODO run_part_opt%allow_doubling, &
-    !       .false. & ! TODO run_part_opt%allow_halving)
-    !)
+
+    call fractal_set_spherical(aero_data_ptr_f%fractal)
+
+    n_modes = 2 
+    n_spec = aero_data_n_spec(aero_data_ptr_f)
+    allocate(aero_dist_init%mode(n_modes))
+    do i_mode = 1,n_modes
+       aero_dist_init%mode(i_mode)%name = mode_names(i_mode)
+       aero_dist_init%mode(i_mode)%type = AERO_MODE_TYPE_LOG_NORMAL
+       aero_dist_init%mode(i_mode)%char_radius = diams(i_mode) / 2
+       aero_dist_init%mode(i_mode)%log10_std_dev_radius = & 
+          log10(std(i_mode))
+       aero_dist_init%mode(i_mode)%num_conc = num_conc(i_mode)
+       allocate(aero_dist_init%mode(i_mode)%vol_frac(n_spec))
+       aero_dist_init%mode(i_mode)%vol_frac = 0.0
+       i_water = aero_data_spec_by_name(aero_data_ptr_f, "H2O")
+       aero_dist_init%mode(i_mode)%vol_frac(i_water) = 1.0
+       allocate(aero_dist_init%mode(i_mode)%vol_frac_std(n_spec))
+       aero_dist_init%mode(i_mode)%vol_frac_std = 0.0
+       source = aero_data_source_by_name(aero_data_ptr_f, mode_names(i_mode))
+       aero_dist_init%mode(i_mode)%source = source 
+    end do
+
+    call aero_state_add_aero_dist_sample(ptr_f, aero_data_ptr_f, &
+           aero_dist_init, 1d0, 0d0, &
+           .true., & ! TODO run_part_opt%allow_doubling, &
+           .true., & ! TODO run_part_opt%allow_halving)
+           n_part_added)
 
   end subroutine
 
@@ -55,5 +88,36 @@ module PyPartMC_aero_state
     call c_f_pointer(ptr_c, ptr_f)
     len = aero_state_n_part(ptr_f)
   end subroutine
+
+  subroutine f_aero_state_num_concs(ptr_c, aero_data_ptr_c, &
+    num_concs, n_parts) bind(C)
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    integer(c_int) :: n_parts
+    real(c_double) :: num_concs(n_parts)
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+
+    num_concs = aero_state_num_concs(ptr_f, aero_data_ptr_f)
+
+  end subroutine
+
+  subroutine f_aero_state_total_num_conc(ptr_c, aero_data_ptr_c, &
+      total_num_conc) bind(C)
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    real(c_double) :: total_num_conc
+ 
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+
+    total_num_conc = aero_state_total_num_conc(ptr_f, aero_data_ptr_f)
+
+  end  subroutine
 
 end module

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -64,8 +64,15 @@ module PyPartMC_aero_state
        aero_dist_init%mode(i_mode)%num_conc = num_conc(i_mode)
        allocate(aero_dist_init%mode(i_mode)%vol_frac(n_spec))
        aero_dist_init%mode(i_mode)%vol_frac = 0.0
-       i_spec = aero_data_spec_by_name(aero_data_ptr_f, "SO4")
-       aero_dist_init%mode(i_mode)%vol_frac(i_spec) = 1.0
+       if (i_mode == 1) then
+          i_spec = aero_data_spec_by_name(aero_data_ptr_f, "SO4")
+          aero_dist_init%mode(i_mode)%vol_frac(i_spec) = 1.0
+       else
+          i_spec = aero_data_spec_by_name(aero_data_ptr_f, "OC")
+          aero_dist_init%mode(i_mode)%vol_frac(i_spec) =  .8 
+          i_spec = aero_data_spec_by_name(aero_data_ptr_f, "BC")
+          aero_dist_init%mode(i_mode)%vol_frac(i_spec) =  .2
+       end if
        allocate(aero_dist_init%mode(i_mode)%vol_frac_std(n_spec))
        aero_dist_init%mode(i_mode)%vol_frac_std = 0.0
        source = aero_data_source_by_name(aero_data_ptr_f, mode_names(i_mode))
@@ -203,6 +210,26 @@ module PyPartMC_aero_state
 
     crit_rel_humids = aero_state_crit_rel_humids(ptr_f, aero_data_ptr_f, &
          env_state_ptr_f)
+
+  end subroutine
+
+  ! FIXME: Add include, exclude, group and groups
+  subroutine f_aero_state_mixing_state_metrics(ptr_c, aero_data_ptr_c, & 
+       d_alpha, d_gamma, chi) bind(C) !, include, exclude, group, groups)&
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    real(c_double) :: d_alpha
+    real(c_double) :: d_gamma
+    real(c_double) :: chi
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+
+    call aero_state_mixing_state_metrics(ptr_f, aero_data_ptr_f, d_alpha, &
+         d_gamma, chi)
+    print*, d_alpha, d_gamma, chi
 
   end subroutine
 

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -127,7 +127,23 @@ module PyPartMC_aero_state
 
     total_num_conc = aero_state_total_num_conc(ptr_f, aero_data_ptr_f)
 
-  end  subroutine
+  end subroutine
+
+  subroutine f_aero_state_total_mass_conc(ptr_c, aero_data_ptr_c, &
+      total_mass_conc) bind(C)
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    real(c_double) :: total_mass_conc
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+
+    total_mass_conc = sum(aero_state_num_concs(ptr_f, aero_data_ptr_f) &
+         * aero_state_masses(ptr_f, aero_data_ptr_f))
+
+  end subroutine
 
   ! FIXME: add include and exclude 
   subroutine f_aero_state_masses(ptr_c, aero_data_ptr_c, masses, n_parts) &

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -54,6 +54,7 @@ module PyPartMC_aero_state
 
     n_modes = 2 
     n_spec = aero_data_n_spec(aero_data_ptr_f)
+    if (n_spec > 1) then
     allocate(aero_dist_init%mode(n_modes))
     do i_mode = 1,n_modes
        aero_dist_init%mode(i_mode)%name = mode_names(i_mode)
@@ -71,7 +72,7 @@ module PyPartMC_aero_state
           i_spec = aero_data_spec_by_name(aero_data_ptr_f, "OC")
           aero_dist_init%mode(i_mode)%vol_frac(i_spec) =  .8 
           i_spec = aero_data_spec_by_name(aero_data_ptr_f, "BC")
-          aero_dist_init%mode(i_mode)%vol_frac(i_spec) =  .2
+             aero_dist_init%mode(i_mode)%vol_frac(i_spec) =  .2
        end if
        allocate(aero_dist_init%mode(i_mode)%vol_frac_std(n_spec))
        aero_dist_init%mode(i_mode)%vol_frac_std = 0.0
@@ -84,6 +85,7 @@ module PyPartMC_aero_state
            .true., & ! TODO run_part_opt%allow_doubling, &
            .true., & ! TODO run_part_opt%allow_halving)
            n_part_added)
+    end if
 
   end subroutine
 
@@ -207,6 +209,8 @@ module PyPartMC_aero_state
     call c_f_pointer(ptr_c, ptr_f)
     call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
     call c_f_pointer(env_state_ptr_c, env_state_ptr_f)
+
+    print*, 'temperature', env_state_ptr_f%temp
 
     crit_rel_humids = aero_state_crit_rel_humids(ptr_f, aero_data_ptr_f, &
          env_state_ptr_f)

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -40,7 +40,7 @@ module PyPartMC_aero_state
     real(kind=dp), parameter, dimension(2) :: diams = [2d-8, 1.16d-7]
     real(kind=dp), parameter, dimension(2) :: std = [1.45,1.65]
     character(len=10), parameter, dimension(2) :: mode_names = ["init_small","init_large"]
-    integer :: n_spec, n_modes, i_mode, i_water
+    integer :: n_spec, n_modes, i_mode, i_spec
     integer :: n_part_added, source
 
     call c_f_pointer(ptr_c, ptr_f)
@@ -64,8 +64,8 @@ module PyPartMC_aero_state
        aero_dist_init%mode(i_mode)%num_conc = num_conc(i_mode)
        allocate(aero_dist_init%mode(i_mode)%vol_frac(n_spec))
        aero_dist_init%mode(i_mode)%vol_frac = 0.0
-       i_water = aero_data_spec_by_name(aero_data_ptr_f, "H2O")
-       aero_dist_init%mode(i_mode)%vol_frac(i_water) = 1.0
+       i_spec = aero_data_spec_by_name(aero_data_ptr_f, "SO4")
+       aero_dist_init%mode(i_mode)%vol_frac(i_spec) = 1.0
        allocate(aero_dist_init%mode(i_mode)%vol_frac_std(n_spec))
        aero_dist_init%mode(i_mode)%vol_frac_std = 0.0
        source = aero_data_source_by_name(aero_data_ptr_f, mode_names(i_mode))
@@ -183,6 +183,26 @@ module PyPartMC_aero_state
     call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
 
     volumes =  aero_state_volumes(ptr_f, aero_data_ptr_f)
+
+  end subroutine
+
+
+  subroutine f_aero_state_crit_rel_humids(ptr_c, aero_data_ptr_c, &
+       env_state_ptr_c, crit_rel_humids, n_parts) bind(C)
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(env_state_t), pointer :: env_state_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c, env_state_ptr_c
+    integer(c_int), intent(in) :: n_parts
+    real(c_double) :: crit_rel_humids(n_parts)
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+    call c_f_pointer(env_state_ptr_c, env_state_ptr_f)
+
+    crit_rel_humids = aero_state_crit_rel_humids(ptr_f, aero_data_ptr_f, &
+         env_state_ptr_f)
 
   end subroutine
 

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -169,4 +169,21 @@ module PyPartMC_aero_state
 
   end subroutine
 
+  ! FIXME: add include and exclude
+  subroutine f_aero_state_volumes(ptr_c, aero_data_ptr_c, volumes, n_parts) &
+       bind(C)
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    integer(c_int) :: n_parts
+    real(c_double) :: volumes(n_parts)
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+
+    volumes =  aero_state_volumes(ptr_f, aero_data_ptr_f)
+
+  end subroutine
+
 end module

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -120,4 +120,53 @@ module PyPartMC_aero_state
 
   end  subroutine
 
+  ! FIXME: add include and exclude 
+  subroutine f_aero_state_masses(ptr_c, aero_data_ptr_c, masses, n_parts) &
+       bind(C) 
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    integer(c_int) :: n_parts
+    real(c_double) :: masses(n_parts)
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+
+    masses =  aero_state_masses(ptr_f, aero_data_ptr_f)
+
+  end subroutine
+
+  subroutine f_aero_state_dry_diameters(ptr_c, aero_data_ptr_c, diameters, n_parts) &
+       bind(C)
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    integer(c_int) :: n_parts
+    real(c_double) :: diameters(n_parts)
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+
+    diameters =  aero_state_dry_diameters(ptr_f, aero_data_ptr_f)
+
+  end subroutine
+
+  subroutine f_aero_state_diameters(ptr_c, aero_data_ptr_c, diameters, &
+       n_parts) bind(C)
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c
+    integer(c_int) :: n_parts
+    real(c_double) :: diameters(n_parts)
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+
+    diameters =  aero_state_diameters(ptr_f, aero_data_ptr_f)
+
+  end subroutine
+
 end module

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -234,4 +234,20 @@ module PyPartMC_aero_state
 
   end subroutine
 
+  subroutine f_aero_state_bin_average_comp(ptr_c, bin_grid_ptr_c, &
+       aero_data_ptr_c) bind(C)
+
+    type(aero_state_t), pointer :: ptr_f => null()
+    type(aero_data_t), pointer :: aero_data_ptr_f => null()
+    type(bin_grid_t), pointer :: bin_grid_ptr_f
+    type(c_ptr), intent(in) :: ptr_c, aero_data_ptr_c, bin_grid_ptr_c
+
+    call c_f_pointer(ptr_c, ptr_f)
+    call c_f_pointer(aero_data_ptr_c, aero_data_ptr_f)
+    call c_f_pointer(bin_grid_ptr_c, bin_grid_ptr_f)
+
+    call aero_state_bin_average_comp(ptr_f, bin_grid_ptr_f, aero_data_ptr_f)
+
+  end subroutine
+
 end module

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -144,7 +144,7 @@ module PyPartMC_aero_state
 
   end subroutine
 
-  ! FIXME: add include and exclude 
+  ! TODO #130: add include and exclude 
   subroutine f_aero_state_masses(ptr_c, aero_data_ptr_c, masses, n_parts) &
        bind(C) 
 
@@ -193,7 +193,7 @@ module PyPartMC_aero_state
 
   end subroutine
 
-  ! FIXME: add include and exclude
+  ! TODO #130: add include and exclude
   subroutine f_aero_state_volumes(ptr_c, aero_data_ptr_c, volumes, n_parts) &
        bind(C)
 
@@ -230,7 +230,7 @@ module PyPartMC_aero_state
 
   end subroutine
 
-  ! FIXME: Add include, exclude, group and groups
+  ! TODO #130: Add include, exclude, group and groups
   subroutine f_aero_state_mixing_state_metrics(ptr_c, aero_data_ptr_c, & 
        d_alpha, d_gamma, chi) bind(C) !, include, exclude, group, groups)&
 

--- a/src/aero_state.hpp
+++ b/src/aero_state.hpp
@@ -22,6 +22,12 @@ extern "C" void f_aero_state_total_num_conc(const void *ptr, const void *aero_da
     double *total_num_conc) noexcept;
 extern "C" void f_aero_state_num_concs(const void *ptr, const void *aero_dataptr, 
     double *num_concs, const int *len) noexcept;
+extern "C" void f_aero_state_masses(const void *ptr, const void *aero_dataptr,
+    double *masses, const int *n_parts) noexcept;
+extern "C" void f_aero_state_dry_diameters(const void *ptr, const void *aero_dataptr,
+    double *dry_diameters, const int *n_parts) noexcept;
+extern "C" void f_aero_state_diameters(const void *ptr, const void *aero_dataptr,
+    double *diameters, const int *n_parts) noexcept;
 
 struct AeroState {
     PMCResource ptr;
@@ -52,5 +58,36 @@ struct AeroState {
         f_aero_state_num_concs(&self.ptr, &aero_data.ptr, begin(num_concs), &len);
 
         return num_concs;
+    }
+
+    static std::valarray<double> masses(const AeroState &self, const AeroData &aero_data){
+        int len;
+        f_aero_state_len(&self.ptr, &len);
+        std::valarray<double> masses(len);
+
+        f_aero_state_masses(&self.ptr, &aero_data.ptr, begin(masses), &len);
+
+        return masses;
+    }
+
+
+   static std::valarray<double> dry_diameters(const AeroState &self, const AeroData &aero_data){
+        int len;
+        f_aero_state_len(&self.ptr, &len);
+        std::valarray<double> dry_diameters(len);
+
+        f_aero_state_dry_diameters(&self.ptr, &aero_data.ptr, begin(dry_diameters), &len);
+
+        return dry_diameters;
+    }
+
+   static std::valarray<double> diameters(const AeroState &self, const AeroData &aero_data){
+        int len;
+        f_aero_state_len(&self.ptr, &len);
+        std::valarray<double> diameters(len);
+
+        f_aero_state_diameters(&self.ptr, &aero_data.ptr, begin(diameters), &len);
+
+        return diameters;
     }
 };

--- a/src/aero_state.hpp
+++ b/src/aero_state.hpp
@@ -33,6 +33,8 @@ extern "C" void f_aero_state_volumes(const void *ptr, const void *aero_dataptr,
     double *volumes, const int *n_parts) noexcept;
 extern "C" void f_aero_state_crit_rel_humids(const void *ptr, const void *aero_dataptr,
        const void *env_stateptr, double *crit_rel_humids, const int *n_parts) noexcept;
+extern "C" void f_aero_state_mixing_state_metrics(const void *aero_state, 
+       const void *aero_data, double *d_alpha, double *d_gamma, double *chi) noexcept;
 
 struct AeroState {
     PMCResource ptr;
@@ -116,5 +118,20 @@ struct AeroState {
              begin(crit_rel_humids), &len);
 
         return crit_rel_humids;
+    }
+
+    static std::tuple<double, double, double> mixing_state(const AeroState &self, 
+        const AeroData &aero_data){
+
+        int len;
+        f_aero_state_len(&self.ptr, &len);
+        double chi;
+        double d_alpha;
+        double d_gamma;
+
+        f_aero_state_mixing_state_metrics(&self.ptr, &aero_data.ptr,
+             &d_alpha, &d_gamma, &chi);
+
+        return std::make_tuple(d_alpha, d_gamma, chi); 
     }
 };

--- a/src/aero_state.hpp
+++ b/src/aero_state.hpp
@@ -8,6 +8,7 @@
 
 #include "pmc_resource.hpp"
 #include "aero_data.hpp"
+#include "pybind11/stl.h"
 
 extern "C" void f_aero_state_ctor(void *ptr) noexcept;
 extern "C" void f_aero_state_dtor(void *ptr) noexcept;
@@ -17,6 +18,10 @@ extern "C" void f_aero_state_init(
     const void *aero_dataptr
 ) noexcept;
 extern "C" void f_aero_state_len(const void *ptr, int *len) noexcept;
+extern "C" void f_aero_state_total_num_conc(const void *ptr, const void *aero_dataptr,
+    double *total_num_conc) noexcept;
+extern "C" void f_aero_state_num_concs(const void *ptr, const void *aero_dataptr, 
+    double *num_concs, const int *len) noexcept;
 
 struct AeroState {
     PMCResource ptr;
@@ -32,5 +37,20 @@ struct AeroState {
         f_aero_state_len(&self.ptr, &len);
         return len;
     }
-};
 
+    static double total_num_conc(const AeroState &self, const AeroData &aero_data){
+        double total_num_conc;
+        f_aero_state_total_num_conc(&self.ptr, &aero_data.ptr, &total_num_conc);
+        return total_num_conc;
+    }
+
+    static std::valarray<double> num_concs(const AeroState &self, const AeroData &aero_data){
+        int len;
+        f_aero_state_len(&self.ptr, &len);
+        std::valarray<double> num_concs(len);
+
+        f_aero_state_num_concs(&self.ptr, &aero_data.ptr, begin(num_concs), &len);
+
+        return num_concs;
+    }
+};

--- a/src/aero_state.hpp
+++ b/src/aero_state.hpp
@@ -9,6 +9,7 @@
 #include "pmc_resource.hpp"
 #include "aero_data.hpp"
 #include "env_state.hpp"
+#include "bin_grid.hpp"
 #include "pybind11/stl.h"
 
 extern "C" void f_aero_state_ctor(void *ptr) noexcept;
@@ -35,6 +36,8 @@ extern "C" void f_aero_state_crit_rel_humids(const void *ptr, const void *aero_d
        const void *env_stateptr, double *crit_rel_humids, const int *n_parts) noexcept;
 extern "C" void f_aero_state_mixing_state_metrics(const void *aero_state, 
        const void *aero_data, double *d_alpha, double *d_gamma, double *chi) noexcept;
+extern "C" void f_aero_state_bin_average_comp(const void *ptr_c, const void *bin_grid_ptr, 
+       const void *aero_data_ptr) noexcept;
 
 struct AeroState {
     PMCResource ptr;
@@ -133,5 +136,11 @@ struct AeroState {
              &d_alpha, &d_gamma, &chi);
 
         return std::make_tuple(d_alpha, d_gamma, chi); 
+    }
+
+    static void bin_average_comp(AeroState &self, const BinGrid &bin_grid, 
+        const AeroData &aero_data){
+
+        f_aero_state_bin_average_comp(&self.ptr, &bin_grid.ptr, &aero_data.ptr);
     }
 };

--- a/src/aero_state.hpp
+++ b/src/aero_state.hpp
@@ -28,6 +28,8 @@ extern "C" void f_aero_state_dry_diameters(const void *ptr, const void *aero_dat
     double *dry_diameters, const int *n_parts) noexcept;
 extern "C" void f_aero_state_diameters(const void *ptr, const void *aero_dataptr,
     double *diameters, const int *n_parts) noexcept;
+extern "C" void f_aero_state_volumes(const void *ptr, const void *aero_dataptr,
+    double *volumes, const int *n_parts) noexcept;
 
 struct AeroState {
     PMCResource ptr;
@@ -89,5 +91,15 @@ struct AeroState {
         f_aero_state_diameters(&self.ptr, &aero_data.ptr, begin(diameters), &len);
 
         return diameters;
+    }
+
+    static std::valarray<double> volumes(const AeroState &self, const AeroData &aero_data){
+        int len;
+        f_aero_state_len(&self.ptr, &len);
+        std::valarray<double> volumes(len);
+
+        f_aero_state_volumes(&self.ptr, &aero_data.ptr, begin(volumes), &len);
+
+        return volumes;
     }
 };

--- a/src/aero_state.hpp
+++ b/src/aero_state.hpp
@@ -22,6 +22,8 @@ extern "C" void f_aero_state_init(
 extern "C" void f_aero_state_len(const void *ptr, int *len) noexcept;
 extern "C" void f_aero_state_total_num_conc(const void *ptr, const void *aero_dataptr,
     double *total_num_conc) noexcept;
+extern "C" void f_aero_state_total_mass_conc(const void *ptr, const void *aero_dataptr,
+    double *total_mass_conc) noexcept;
 extern "C" void f_aero_state_num_concs(const void *ptr, const void *aero_dataptr, 
     double *num_concs, const int *len) noexcept;
 extern "C" void f_aero_state_masses(const void *ptr, const void *aero_dataptr,
@@ -60,6 +62,12 @@ struct AeroState {
         return total_num_conc;
     }
 
+    static double total_mass_conc(const AeroState &self, const AeroData &aero_data){
+        double total_mass_conc;
+        f_aero_state_total_mass_conc(&self.ptr, &aero_data.ptr, &total_mass_conc);
+        return total_mass_conc;
+    }
+
     static std::valarray<double> num_concs(const AeroState &self, const AeroData &aero_data){
         int len;
         f_aero_state_len(&self.ptr, &len);
@@ -79,7 +87,6 @@ struct AeroState {
 
         return masses;
     }
-
 
    static std::valarray<double> dry_diameters(const AeroState &self, const AeroData &aero_data){
         int len;

--- a/src/aero_state.hpp
+++ b/src/aero_state.hpp
@@ -8,6 +8,7 @@
 
 #include "pmc_resource.hpp"
 #include "aero_data.hpp"
+#include "env_state.hpp"
 #include "pybind11/stl.h"
 
 extern "C" void f_aero_state_ctor(void *ptr) noexcept;
@@ -30,6 +31,8 @@ extern "C" void f_aero_state_diameters(const void *ptr, const void *aero_dataptr
     double *diameters, const int *n_parts) noexcept;
 extern "C" void f_aero_state_volumes(const void *ptr, const void *aero_dataptr,
     double *volumes, const int *n_parts) noexcept;
+extern "C" void f_aero_state_crit_rel_humids(const void *ptr, const void *aero_dataptr,
+       const void *env_stateptr, double *crit_rel_humids, const int *n_parts) noexcept;
 
 struct AeroState {
     PMCResource ptr;
@@ -101,5 +104,17 @@ struct AeroState {
         f_aero_state_volumes(&self.ptr, &aero_data.ptr, begin(volumes), &len);
 
         return volumes;
+    }
+
+    static std::valarray<double> crit_rel_humids(const AeroState &self, const AeroData &aero_data,
+        const EnvState &env_state){
+        int len;
+        f_aero_state_len(&self.ptr, &len);
+        std::valarray<double> crit_rel_humids(len);
+
+        f_aero_state_crit_rel_humids(&self.ptr, &aero_data.ptr, &env_state.ptr, 
+             begin(crit_rel_humids), &len);
+
+        return crit_rel_humids;
     }
 };

--- a/src/env_state.F90
+++ b/src/env_state.F90
@@ -35,4 +35,15 @@ module PyPartMC_env_state
         call spec_file_read_env_state(file, ptr_f)
     end subroutine
 
+    subroutine f_env_state_set_temperature(ptr_c, temperature) bind(C)
+        type(env_state_t), pointer :: ptr_f => null()
+        type(c_ptr), intent(in) :: ptr_c
+        real(c_double), intent(in) :: temperature
+
+        call c_f_pointer(ptr_c, ptr_f)
+
+        ptr_f%temp = temperature
+
+    end subroutine
+
 end module

--- a/src/env_state.F90
+++ b/src/env_state.F90
@@ -46,4 +46,26 @@ module PyPartMC_env_state
 
     end subroutine
 
+    subroutine f_env_state_get_temperature(ptr_c, temperature) bind(C)
+        type(env_state_t), pointer :: ptr_f => null()
+        type(c_ptr), intent(in) :: ptr_c
+        real(c_double), intent(out) :: temperature
+
+        call c_f_pointer(ptr_c, ptr_f)
+
+        temperature = ptr_f%temp
+
+    end subroutine
+
+    subroutine f_env_state_get_rel_humid(ptr_c, rel_humid) bind(C)
+        type(env_state_t), pointer :: ptr_f => null()
+        type(c_ptr), intent(in) :: ptr_c
+        real(c_double), intent(out) :: rel_humid
+
+        call c_f_pointer(ptr_c, ptr_f)
+
+        rel_humid = ptr_f%rel_humid
+
+    end subroutine
+
 end module

--- a/src/env_state.hpp
+++ b/src/env_state.hpp
@@ -13,6 +13,8 @@ extern "C" void f_env_state_ctor(void *ptr) noexcept;
 extern "C" void f_env_state_dtor(void *ptr) noexcept;
 extern "C" void f_env_state_from_json(const void *ptr) noexcept;
 extern "C" void f_env_state_set_temperature(const void *ptr, const double *temperature) noexcept;
+extern "C" void f_env_state_get_temperature(const void *ptr, double *temperature) noexcept;
+extern "C" void f_env_state_get_rel_humid(const void *ptr, double *rel_humid) noexcept;
 
 struct EnvState {
     PMCResource ptr;
@@ -29,5 +31,17 @@ struct EnvState {
         f_env_state_set_temperature(&self.ptr, &temperature);
     }
 
-};
+    static double temp(const EnvState &self){
+        double temperature;
 
+        f_env_state_get_temperature(&self.ptr, &temperature);
+        return temperature;
+    }
+
+    static double rh(const EnvState &self){
+        double rel_humid;
+
+        f_env_state_get_rel_humid(&self.ptr, &rel_humid);
+        return rel_humid;
+    }
+};

--- a/src/env_state.hpp
+++ b/src/env_state.hpp
@@ -12,6 +12,7 @@
 extern "C" void f_env_state_ctor(void *ptr) noexcept;
 extern "C" void f_env_state_dtor(void *ptr) noexcept;
 extern "C" void f_env_state_from_json(const void *ptr) noexcept;
+extern "C" void f_env_state_set_temperature(const void *ptr, const double *temperature) noexcept;
 
 struct EnvState {
     PMCResource ptr;
@@ -23,5 +24,10 @@ struct EnvState {
         f_env_state_from_json(this->ptr.f_arg());
         gimmick_ptr().reset();
     }
+
+    static void set_temperature(const EnvState &self, double &temperature){
+        f_env_state_set_temperature(&self.ptr, &temperature);
+    }
+
 };
 

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -98,6 +98,8 @@ PYBIND11_MODULE(_PyPartMC, m) {
             "returns the critical relative humidity of each particle in the population")
         .def("mixing_state", AeroState::mixing_state,
             "returns the mixing state parameters (chi,d_alpha,d_gamma) of the population")
+        .def("bin_average_comp", AeroState::bin_average_comp,
+            "composition-averages population using BinGrid")
     ;
 
     py::class_<GasData>(m, "GasData",

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -88,6 +88,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         .def("volumes", AeroState::volumes)
         .def("dry_diameters", AeroState::dry_diameters)
         .def("diameters", AeroState::diameters)
+        .def("crit_rel_humids", AeroState::crit_rel_humids)
     ;
 
     py::class_<GasData>(m, "GasData",

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -84,6 +84,8 @@ PYBIND11_MODULE(_PyPartMC, m) {
         .def("__len__", AeroState::__len__)
         .def("total_num_conc", AeroState::total_num_conc,
             "returns the total number concentration of the population")
+        .def("total_mass_conc", AeroState::total_mass_conc,
+            "returns the total mass concentration of the population")
         .def("num_concs", AeroState::num_concs,
             "returns the number concentration of each particle in the population")
         .def("masses", AeroState::masses,

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -122,6 +122,8 @@ PYBIND11_MODULE(_PyPartMC, m) {
     )
         .def(py::init<const nlohmann::json&>())
         .def("set_temperature", EnvState::set_temperature)
+        .def_property_readonly("temp", EnvState::temp)
+        .def_property_readonly("rh", EnvState::rh)
     ;
 
     py::class_<Scenario>(m,

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -82,14 +82,22 @@ PYBIND11_MODULE(_PyPartMC, m) {
     )
         .def(py::init<const double, const AeroData&>())
         .def("__len__", AeroState::__len__)
-        .def("total_num_conc", AeroState::total_num_conc)
-        .def("num_concs", AeroState::num_concs)
-        .def("masses", AeroState::masses)
-        .def("volumes", AeroState::volumes)
-        .def("dry_diameters", AeroState::dry_diameters)
-        .def("diameters", AeroState::diameters)
-        .def("crit_rel_humids", AeroState::crit_rel_humids)
-        .def("mixing_state", AeroState::mixing_state)
+        .def("total_num_conc", AeroState::total_num_conc,
+            "returns the total number concentration of the population")
+        .def("num_concs", AeroState::num_concs,
+            "returns the number concentration of each particle in the population")
+        .def("masses", AeroState::masses,
+            "returns the total mass of each particle in the population")
+        .def("volumes", AeroState::volumes,
+            "returns the total volume of each particle in the population")
+        .def("dry_diameters", AeroState::dry_diameters,
+            "returns the dry diameter of each particle in the population")
+        .def("diameters", AeroState::diameters,
+            "returns the diameter of each particle in the population")
+        .def("crit_rel_humids", AeroState::crit_rel_humids,
+            "returns the critical relative humidity of each particle in the population")
+        .def("mixing_state", AeroState::mixing_state,
+            "returns the mixing state parameters (chi,d_alpha,d_gamma) of the population")
     ;
 
     py::class_<GasData>(m, "GasData",
@@ -121,9 +129,12 @@ PYBIND11_MODULE(_PyPartMC, m) {
         )pbdoc"
     )
         .def(py::init<const nlohmann::json&>())
-        .def("set_temperature", EnvState::set_temperature)
-        .def_property_readonly("temp", EnvState::temp)
-        .def_property_readonly("rh", EnvState::rh)
+        .def("set_temperature", EnvState::set_temperature,
+            "sets the temperature of the environment state")
+        .def_property_readonly("temp", EnvState::temp,
+            "returns the current temperature of the environment state")
+        .def_property_readonly("rh", EnvState::rh,
+            "returns the current relative humidity of the environment state")
     ;
 
     py::class_<Scenario>(m,

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -121,6 +121,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         )pbdoc"
     )
         .def(py::init<const nlohmann::json&>())
+        .def("set_temperature", EnvState::set_temperature)
     ;
 
     py::class_<Scenario>(m,

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -84,6 +84,9 @@ PYBIND11_MODULE(_PyPartMC, m) {
         .def("__len__", AeroState::__len__)
         .def("total_num_conc", AeroState::total_num_conc)
         .def("num_concs", AeroState::num_concs)
+        .def("masses", AeroState::masses)
+        .def("dry_diameters", AeroState::dry_diameters)
+        .def("diameters", AeroState::diameters)
     ;
 
     py::class_<GasData>(m, "GasData",

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -82,6 +82,8 @@ PYBIND11_MODULE(_PyPartMC, m) {
     )
         .def(py::init<const double, const AeroData&>())
         .def("__len__", AeroState::__len__)
+        .def("total_num_conc", AeroState::total_num_conc)
+        .def("num_concs", AeroState::num_concs)
     ;
 
     py::class_<GasData>(m, "GasData",

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -85,6 +85,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         .def("total_num_conc", AeroState::total_num_conc)
         .def("num_concs", AeroState::num_concs)
         .def("masses", AeroState::masses)
+        .def("volumes", AeroState::volumes)
         .def("dry_diameters", AeroState::dry_diameters)
         .def("diameters", AeroState::diameters)
     ;

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -89,6 +89,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         .def("dry_diameters", AeroState::dry_diameters)
         .def("diameters", AeroState::diameters)
         .def("crit_rel_humids", AeroState::crit_rel_humids)
+        .def("mixing_state", AeroState::mixing_state)
     ;
 
     py::class_<GasData>(m, "GasData",


### PR DESCRIPTION
Rough draft of adding some aero_state capabilities.

- Retrieve the total number concentrations (`aero_state.total_num_conc(aero_data)`)
- Retrieve the number concentrations of each particle (`aero_state.num_concs(aero_data)`)
- Temporarily added an `aero_dist_init` and enabled sampling so that the `aero_state` is initialized with some particles. will be replaced once we have `aero_dist` and `aero_modes` available.

To do:

- [x] mixing state parameters
- [x] composition-averaging
- [x] aero_state_crit_rel_humids
- [x] aero_state_dry_diameters, aero_state_diameters
- [x] aero_state_volumes, aero_state_masses