### PR TITLE
Access to more information in aero_particle (+ execute rand_init before each test, not just once per test session)

### DIFF
--- a/src/aero_data.F90
+++ b/src/aero_data.F90
@@ -185,4 +185,15 @@ module PyPartMC_aero_data
 
   end subroutine
 
+  subroutine f_aero_data_n_source(ptr_c, n_source) bind(C)
+    type(aero_data_t), pointer :: ptr_f => null()
+    type(c_ptr), intent(in) :: ptr_c
+    integer(c_int) :: n_source
+
+    call c_f_pointer(ptr_c, ptr_f)
+
+    n_source = aero_data_n_source(ptr_f)
+
+  end subroutine
+
 end module

--- a/src/aero_data.hpp
+++ b/src/aero_data.hpp
@@ -14,6 +14,7 @@ extern "C" void f_aero_data_dtor(void *ptr) noexcept;
 extern "C" void f_aero_data_from_json(const void *ptr) noexcept;
 extern "C" void f_aero_data_spec_by_name(const void *ptr, int *value, const char *name_data, const int *name_size) noexcept;
 extern "C" void f_aero_data_len(const void *ptr, int *len) noexcept;
+extern "C" void f_aero_data_n_source(const void *ptr, int *len) noexcept;
 extern "C" void f_aero_data_set_frac_dim(void *ptr, const double*) noexcept;
 extern "C" void f_aero_data_get_frac_dim(const void *ptr, double*) noexcept;
 extern "C" void f_aero_data_set_vol_fill_factor(void *ptr, const double*) noexcept;
@@ -191,6 +192,15 @@ struct AeroData {
         );
 
         return data;
+    }
+
+    static std::size_t n_source(const AeroData &self) {
+        int len;
+        f_aero_data_n_source(
+            self.ptr.f_arg(),
+            &len
+        );
+        return len;
     }
 
 };

--- a/src/aero_data.hpp
+++ b/src/aero_data.hpp
@@ -200,6 +200,8 @@ struct AeroData {
             self.ptr.f_arg(),
             &len
         );
+        if (len == -1)
+            throw std::runtime_error("No sources defined.");
         return len;
     }
 

--- a/src/aero_particle.F90
+++ b/src/aero_particle.F90
@@ -494,4 +494,34 @@ module PyPartMC_aero_particle
 
   end subroutine
 
+  subroutine f_aero_particle_refract_shell( &
+      aero_particle_ptr_c, &
+      refract_shell &
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    complex(c_double_complex), intent(out) :: refract_shell
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    refract_shell = aero_particle_ptr_f%refract_shell
+
+  end subroutine
+
+  subroutine f_aero_particle_refract_core( &
+      aero_particle_ptr_c, &
+      refract_core &
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    complex(c_double_complex), intent(out) :: refract_core
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    refract_core = aero_particle_ptr_f%refract_core
+
+  end subroutine
+
 end module

--- a/src/aero_particle.F90
+++ b/src/aero_particle.F90
@@ -387,4 +387,96 @@ module PyPartMC_aero_particle
     )
   end subroutine
 
+  subroutine f_aero_particle_absorb_cross_sect( &
+      aero_particle_ptr_c, &
+      absorb_cross_sect & 
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    real(c_double), intent(out) :: absorb_cross_sect    
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    absorb_cross_sect = aero_particle_ptr_f%absorb_cross_sect
+
+  end subroutine
+
+  subroutine f_aero_particle_scatter_cross_sect( &
+      aero_particle_ptr_c, &
+      scatter_cross_sect &
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    real(c_double), intent(out) :: scatter_cross_sect
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    scatter_cross_sect = aero_particle_ptr_f%scatter_cross_sect
+
+  end subroutine
+
+  subroutine f_aero_particle_asymmetry( &
+      aero_particle_ptr_c, &
+      asymmetry &
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    real(c_double), intent(out) :: asymmetry
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    asymmetry = aero_particle_ptr_f%asymmetry
+
+  end subroutine
+
+  subroutine f_aero_particle_greatest_create_time( &
+      aero_particle_ptr_c, &
+      greatest_create_time &
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    real(c_double), intent(out) :: greatest_create_time
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    greatest_create_time = aero_particle_ptr_f%greatest_create_time
+
+  end subroutine
+
+  subroutine f_aero_particle_least_create_time( &
+      aero_particle_ptr_c, &
+      least_create_time &
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    real(c_double), intent(out) :: least_create_time
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    least_create_time = aero_particle_ptr_f%least_create_time
+
+  end subroutine
+
+  subroutine f_aero_particle_n_orig_part( &
+      aero_particle_ptr_c, &
+      n_orig_part, &
+      n_orig_part_size &
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    integer(c_int), intent(in) :: n_orig_part_size
+    integer(c_int), dimension(n_orig_part_size), intent(out) :: n_orig_part
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    n_orig_part = aero_particle_ptr_f%n_orig_part
+
+  end subroutine
+
 end module

--- a/src/aero_particle.F90
+++ b/src/aero_particle.F90
@@ -479,4 +479,19 @@ module PyPartMC_aero_particle
 
   end subroutine
 
+  subroutine f_aero_particle_id( & 
+      aero_particle_ptr_c, &
+      id &
+    ) bind(C)
+
+    type(aero_particle_t), pointer :: aero_particle_ptr_f => null()
+    type(c_ptr), intent(in) :: aero_particle_ptr_c
+    integer(c_int), intent(out) :: id
+
+    call c_f_pointer(aero_particle_ptr_c, aero_particle_ptr_f)
+
+    id = aero_particle_ptr_f%id
+
+  end subroutine
+
 end module

--- a/src/aero_particle.hpp
+++ b/src/aero_particle.hpp
@@ -35,6 +35,12 @@ extern "C" void f_aero_particle_crit_diameter(const void *aero_particle_ptr, con
 extern "C" void f_aero_particle_coagulate(const void *aero_particle_1_ptr, const void *aero_particle_2_ptr, void *new_particle_ptr) noexcept;
 extern "C" void f_aero_particle_zero(void *aero_particle_ptr, const void *aero_data_ptr) noexcept;
 extern "C" void f_aero_particle_set_vols(void *aero_particle_ptr, const int *vol_size, const void *volumes) noexcept;
+extern "C" void f_aero_particle_absorb_cross_sect(const void *aero_particle_ptr, double *val) noexcept;
+extern "C" void f_aero_particle_scatter_cross_sect(const void *aero_particle_ptr, double *val) noexcept;
+extern "C" void f_aero_particle_asymmetry(const void *aero_particle_ptr, double *val) noexcept;
+extern "C" void f_aero_particle_greatest_create_time(const void *aero_particle_ptr, double *val) noexcept;
+extern "C" void f_aero_particle_least_create_time(const void *aero_particle_ptr, double *val) noexcept;
+extern "C" void f_aero_particle_n_orig_part(const void *aero_particle_ptr, void *arr_data, const int *arr_size) noexcept;
 
 namespace py = pybind11;
 struct AeroParticle {
@@ -270,6 +276,63 @@ struct AeroParticle {
             &len,
             begin(volumes)
         );
+    }
+
+    static auto scatter_cross_sect(const AeroParticle &self) {
+        double val;
+        f_aero_particle_scatter_cross_sect(
+            self.ptr.f_arg(),
+            &val
+        );
+        return val;
+    }
+
+    static auto absorb_cross_sect(const AeroParticle &self) {
+        double val;
+        f_aero_particle_absorb_cross_sect(
+            self.ptr.f_arg(),
+            &val
+        );
+        return val;
+    }
+
+    static auto asymmetry(const AeroParticle &self) {
+        double val;
+        f_aero_particle_asymmetry(
+            self.ptr.f_arg(),
+            &val
+        );
+        return val;
+    }
+
+    static auto n_orig_part(const AeroParticle &self) {
+        int len = AeroData::n_source(*self.aero_data);
+        std::valarray<int> data(len);
+
+        f_aero_particle_n_orig_part(
+            self.ptr.f_arg(),
+            begin(data),
+            &len
+        );
+        return data;
+    }
+
+    static auto least_create_time(const AeroParticle &self) {
+        double val;
+        f_aero_particle_least_create_time(
+            self.ptr.f_arg(),
+            &val
+        );
+        return val;
+    }
+
+    static auto greatest_create_time(const AeroParticle &self) {
+        double val;
+        f_aero_particle_greatest_create_time(
+            self.ptr.f_arg(),
+            &val
+        );
+        return val;
     }
 
 };

--- a/src/aero_particle.hpp
+++ b/src/aero_particle.hpp
@@ -41,6 +41,7 @@ extern "C" void f_aero_particle_asymmetry(const void *aero_particle_ptr, double 
 extern "C" void f_aero_particle_greatest_create_time(const void *aero_particle_ptr, double *val) noexcept;
 extern "C" void f_aero_particle_least_create_time(const void *aero_particle_ptr, double *val) noexcept;
 extern "C" void f_aero_particle_n_orig_part(const void *aero_particle_ptr, void *arr_data, const int *arr_size) noexcept;
+extern "C" void f_aero_particle_id(const void *aero_particle_ptr, int *val) noexcept;
 
 namespace py = pybind11;
 struct AeroParticle {
@@ -329,6 +330,15 @@ struct AeroParticle {
     static auto greatest_create_time(const AeroParticle &self) {
         double val;
         f_aero_particle_greatest_create_time(
+            self.ptr.f_arg(),
+            &val
+        );
+        return val;
+    }
+
+    static auto id(const AeroParticle &self) {
+        int val;
+        f_aero_particle_id(
             self.ptr.f_arg(),
             &val
         );

--- a/src/aero_particle.hpp
+++ b/src/aero_particle.hpp
@@ -10,6 +10,7 @@
 #include "aero_data.hpp"
 #include "env_state.hpp"
 #include "pybind11/stl.h"
+#include <complex>
 
 extern "C" void f_aero_particle_ctor(void *ptr) noexcept;
 extern "C" void f_aero_particle_dtor(void *ptr) noexcept;
@@ -42,6 +43,8 @@ extern "C" void f_aero_particle_greatest_create_time(const void *aero_particle_p
 extern "C" void f_aero_particle_least_create_time(const void *aero_particle_ptr, double *val) noexcept;
 extern "C" void f_aero_particle_n_orig_part(const void *aero_particle_ptr, void *arr_data, const int *arr_size) noexcept;
 extern "C" void f_aero_particle_id(const void *aero_particle_ptr, int *val) noexcept;
+extern "C" void f_aero_particle_refract_shell(const void *aero_particle_ptr, std::complex<double> *val) noexcept;
+extern "C" void f_aero_particle_refract_core(const void *aero_particle_ptr, std::complex<double> *val) noexcept;
 
 namespace py = pybind11;
 struct AeroParticle {
@@ -345,4 +348,21 @@ struct AeroParticle {
         return val;
     }
 
+    static auto refract_shell(const AeroParticle &self) {
+        std::complex<double> refract_shell;
+        f_aero_particle_refract_shell(
+            self.ptr.f_arg(),
+            &refract_shell
+        );
+        return refract_shell;
+    }
+
+    static auto refract_core(const AeroParticle &self) {
+        std::complex<double> refract_core;
+        f_aero_particle_refract_core(
+            self.ptr.f_arg(),
+            &refract_core
+        );
+        return refract_core;
+    }
 };

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -76,6 +76,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         .def(py::init<const nlohmann::json&>())
         .def("spec_by_name", AeroData::spec_by_name)
         .def("__len__", AeroData::__len__)
+        .def("n_source", AeroData::n_source)
         .def_property("frac_dim", &AeroData::get_frac_dim, &AeroData::set_frac_dim)
         .def_property("vol_fill_factor", &AeroData::get_vol_fill_factor, &AeroData::set_vol_fill_factor)
         .def_property("prime_radius", &AeroData::get_prime_radius, &AeroData::set_prime_radius)
@@ -128,6 +129,18 @@ PYBIND11_MODULE(_PyPartMC, m) {
             "Returns the average of the solute kappas (1).")
         .def_property_readonly("moles", AeroParticle::moles,
             "Total moles in the particle (1).")
+        .def_property_readonly("absorb_cross_sect", AeroParticle::absorb_cross_sect,
+            "Absorption cross-section (m^-2).")
+        .def_property_readonly("scatter_cross_sect", AeroParticle::scatter_cross_sect,
+            "Scattering cross-section (m^-2).")
+        .def_property_readonly("asymmetry", AeroParticle::asymmetry,
+            "Asymmetry parameter (1).")
+        .def_property_readonly("n_orig_part", AeroParticle::n_orig_part,
+            "Number of original particles from each source that coagulated to form particle.")
+        .def_property_readonly("least_create_time", AeroParticle::least_create_time,
+            "First time a constituent was created (s).")
+        .def_property_readonly("greatest_create_time", AeroParticle::greatest_create_time,
+            "Last time a constituent was created (s).")
         .def("mobility_diameter", AeroParticle::mobility_diameter,
             "Mobility diameter of the particle (m).")
         .def_property_readonly("density", AeroParticle::density,

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -7,6 +7,7 @@
 #include "pybind11/pybind11.h"
 #include "nlohmann/json.hpp"
 #include "pybind11_json/pybind11_json.hpp"
+#include "pybind11/complex.h"
 
 #include "util.hpp"
 #include "rand.hpp"
@@ -135,6 +136,10 @@ PYBIND11_MODULE(_PyPartMC, m) {
             "Scattering cross-section (m^-2).")
         .def_property_readonly("asymmetry", AeroParticle::asymmetry,
             "Asymmetry parameter (1).")
+        .def_property_readonly("refract_shell", AeroParticle::refract_shell,
+            "Refractive index of the shell (1).")
+        .def_property_readonly("refract_core", AeroParticle::refract_core,
+            "Refractive index of the core (1).")
         .def_property_readonly("n_orig_part", AeroParticle::n_orig_part,
             "Number of original particles from each source that coagulated to form particle.")
         .def_property_readonly("least_create_time", AeroParticle::least_create_time,

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -77,7 +77,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         .def(py::init<const nlohmann::json&>())
         .def("spec_by_name", AeroData::spec_by_name)
         .def("__len__", AeroData::__len__)
-        .def("n_source", AeroData::n_source)
+        .def_property_readonly("n_source", AeroData::n_source)
         .def_property("frac_dim", &AeroData::get_frac_dim, &AeroData::set_frac_dim)
         .def_property("vol_fill_factor", &AeroData::get_vol_fill_factor, &AeroData::set_vol_fill_factor)
         .def_property("prime_radius", &AeroData::get_prime_radius, &AeroData::set_prime_radius)

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -141,6 +141,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
             "First time a constituent was created (s).")
         .def_property_readonly("greatest_create_time", AeroParticle::greatest_create_time,
             "Last time a constituent was created (s).")
+        .def_property_readonly("id", AeroParticle::id, "Unique ID number.")
         .def("mobility_diameter", AeroParticle::mobility_diameter,
             "Mobility diameter of the particle (m).")
         .def_property_readonly("density", AeroParticle::density,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import pytest
 import PyPartMC as ppmc
 
-ppmc.rand_init(44)
+
+@pytest.fixture(autouse=True)
+def rand_init():
+    ppmc.rand_init(44)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 import PyPartMC as ppmc
 
 

--- a/tests/test_aero_data.py
+++ b/tests/test_aero_data.py
@@ -362,3 +362,15 @@ class TestAeroData:
 
         # assert
         assert str(exc_info.value) == "Species names must be unique"
+
+    @staticmethod
+    def test_n_source_uninitialized():
+        # arrange
+        sut = ppmc.AeroData(AERO_DATA_CTOR_ARG_FULL)
+
+        # act
+        with pytest.raises(Exception) as exc_info:
+            _ = sut.n_source
+
+        # assert
+        assert str(exc_info.value) == "No sources defined."

--- a/tests/test_aero_particle.py
+++ b/tests/test_aero_particle.py
@@ -496,3 +496,123 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert sut.volumes == [3, 2, 1]
+
+    @staticmethod
+    def test_absorb_cross_sect():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        value = sut.absorb_cross_sect
+
+        # assert
+        assert value == 0
+        assert type(value) == float
+
+    @staticmethod
+    def test_scatter_cross_sect():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        value = sut.scatter_cross_sect
+
+        # assert
+        assert value == 0
+        assert type(value) == float
+
+    @staticmethod
+    def test_asymmetry():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        value = sut.asymmetry
+
+        # assert
+        assert value == 0
+        assert type(value) == float
+
+    @staticmethod
+    def test_refract_shell():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        value = sut.refract_shell
+
+        # assert
+        assert value == 0 + 0j
+        assert type(value) == complex
+
+    @staticmethod
+    def test_refract_core():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        value = sut.refract_core
+
+        # assert
+        assert value == 0 + 0j
+        assert type(value) == complex
+
+    @staticmethod
+    def test_n_orig_part():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        with pytest.raises(Exception) as exc_info:
+            _ = sut.n_orig_part
+
+        # assert
+        assert str(exc_info.value) == "No sources defined."
+
+    @staticmethod
+    def test_least_create_time():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        time = sut.least_create_time
+
+        # assert
+        assert time == 0
+        assert type(time) == float
+
+    @staticmethod
+    def test_greatest_create_time():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        time = sut.greatest_create_time
+
+        # assert
+        assert time == 0
+        assert type(time) == float
+
+    @staticmethod
+    def test_id():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        pid = sut.id
+
+        # assert
+        assert pid == 0
+        assert type(pid) == int
+
+    @staticmethod
+    def test_density():
+        # arrange
+        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+
+        # act
+        density = sut.density
+
+        # assert
+        assert density > 0
+        assert type(density) == float

--- a/tests/test_aero_particle.py
+++ b/tests/test_aero_particle.py
@@ -507,7 +507,7 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert value == 0
-        assert type(value) == float
+        assert isinstance(value, float)
 
     @staticmethod
     def test_scatter_cross_sect():
@@ -519,7 +519,7 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert value == 0
-        assert type(value) == float
+        assert isinstance(value, float)
 
     @staticmethod
     def test_asymmetry():
@@ -531,7 +531,7 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert value == 0
-        assert type(value) == float
+        assert isinstance(value, float)
 
     @staticmethod
     def test_refract_shell():
@@ -543,7 +543,7 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert value == 0 + 0j
-        assert type(value) == complex
+        assert isinstance(value, complex)
 
     @staticmethod
     def test_refract_core():
@@ -555,7 +555,7 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert value == 0 + 0j
-        assert type(value) == complex
+        assert isinstance(value, complex)
 
     @staticmethod
     def test_n_orig_part():
@@ -579,7 +579,7 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert time == 0
-        assert type(time) == float
+        assert isinstance(time, float)
 
     @staticmethod
     def test_greatest_create_time():
@@ -591,7 +591,7 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert time == 0
-        assert type(time) == float
+        assert isinstance(time, float)
 
     @staticmethod
     def test_id():
@@ -603,16 +603,4 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
 
         # assert
         assert pid == 0
-        assert type(pid) == int
-
-    @staticmethod
-    def test_density():
-        # arrange
-        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
-
-        # act
-        density = sut.density
-
-        # assert
-        assert density > 0
-        assert type(density) == float
+        assert isinstance(pid, int)

--- a/tests/test_aero_particle.py
+++ b/tests/test_aero_particle.py
@@ -13,6 +13,8 @@ import PyPartMC as ppmc
 from PyPartMC import si
 
 from .test_aero_data import AERO_DATA_CTOR_ARG_MINIMAL
+from .test_aero_dist import AERO_DIST_CTOR_ARG_MINIMAL
+from .test_aero_state import AERO_STATE_CTOR_ARG_MINIMAL
 from .test_env_state import ENV_STATE_CTOR_ARG_MINIMAL
 
 
@@ -560,47 +562,68 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
     @staticmethod
     def test_n_orig_part():
         # arrange
-        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
-
+        aero_data = ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL)
+        aero_dist = ppmc.AeroDist(aero_data, AERO_DIST_CTOR_ARG_MINIMAL)
+        aero_state = ppmc.AeroState(aero_data, *AERO_STATE_CTOR_ARG_MINIMAL)
+        _ = aero_state.dist_sample(aero_dist, 1.0, 0.0)
+        sut = aero_state.particle(0)
         # act
-        with pytest.raises(Exception) as exc_info:
-            _ = sut.n_orig_part
+        n_orig_part = sut.n_orig_part
 
         # assert
-        assert str(exc_info.value) == "No sources defined."
+        assert len(n_orig_part) == aero_dist.n_mode
+        assert isinstance(n_orig_part[0], int)
 
     @staticmethod
     def test_least_create_time():
         # arrange
-        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+        create_time = 44.0
+        aero_data = ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL)
+        aero_dist = ppmc.AeroDist(aero_data, AERO_DIST_CTOR_ARG_MINIMAL)
+        aero_state = ppmc.AeroState(aero_data, *AERO_STATE_CTOR_ARG_MINIMAL)
+        _ = aero_state.dist_sample(aero_dist, 1.0, create_time)
 
         # act
-        time = sut.least_create_time
+        time = []
+        for i_part in range(len(aero_state)):
+            time.append(aero_state.particle(i_part).least_create_time)
 
         # assert
-        assert time == 0
-        assert isinstance(time, float)
+        assert np.all(np.isclose(time, create_time))
+        assert isinstance(time[0], float)
 
     @staticmethod
     def test_greatest_create_time():
         # arrange
-        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+        create_time = 44.0
+        aero_data = ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL)
+        aero_dist = ppmc.AeroDist(aero_data, AERO_DIST_CTOR_ARG_MINIMAL)
+        aero_state = ppmc.AeroState(aero_data, *AERO_STATE_CTOR_ARG_MINIMAL)
+        _ = aero_state.dist_sample(aero_dist, 1.0, create_time)
 
         # act
-        time = sut.greatest_create_time
+        time = []
+        for i_part in range(len(aero_state)):
+            time.append(aero_state.particle(i_part).greatest_create_time)
 
         # assert
-        assert time == 0
-        assert isinstance(time, float)
+        assert np.all(np.isclose(time, create_time))
+        assert isinstance(time[0], float)
 
     @staticmethod
     def test_id():
         # arrange
-        sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
+        aero_data = ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL)
+        aero_dist = ppmc.AeroDist(aero_data, AERO_DIST_CTOR_ARG_MINIMAL)
+        aero_state = ppmc.AeroState(aero_data, *AERO_STATE_CTOR_ARG_MINIMAL)
+        _ = aero_state.dist_sample(aero_dist, 1.0, 0.0)
 
         # act
-        pid = sut.id
+        ids = []
+        for i_part in range(len(aero_state)):
+            ids.append(aero_state.particle(i_part).id)
 
         # assert
-        assert pid == 0
-        assert isinstance(pid, int)
+        assert isinstance(ids[0], int)
+        assert min(ids) > 0
+        assert len(np.unique(ids)) == len(aero_state)


### PR DESCRIPTION
Add access to almost all the missing read only values of `aero_particle` structure as desired in #277 