### PR TITLE
warn user if any of the submodules is not initialised

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,13 @@
 
 cmake_minimum_required(VERSION 3.8)  # CXX17
 
-if (NOT EXISTS "${CMAKE_SOURCE_DIR}/gitmodules/pybind11/include/pybind11/pybind11.h" )
-  message(FATAL_ERROR "git submodules not initialised.\n Please run `git submodule update --init`")
-endif()
+file(GLOB mods RELATIVE ${CMAKE_SOURCE_DIR} gitmodules/*)
+foreach(mod ${mods})
+  file(GLOB tmp RELATIVE ${CMAKE_SOURCE_DIR} ${mod}/*)
+  if (tmp STREQUAL "")
+    message(FATAL_ERROR "git submodule ${mod} not initialised.\n Please run `git submodule update --init`")
+  endif()
+endforeach()
 
 project(_PyPartMC LANGUAGES C CXX Fortran)
 


### PR DESCRIPTION
(previously only pybind11 was checked assuming that we are operating on a fresh clone, the new logic ensures that if a module is added later on, and a local clone is updated, the warning would still inform the user of the need to update submodules)