### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Code of conduct for the PyPartMC open-source project
+
+As [contributors and maintainers of this project](https://github.com/open-atmos/PyPartMC/graphs/contributors),
+and in the interest of fostering an open and welcoming community, we pledge to respect all
+people who contribute through reporting issues, posting feature requests, updating 
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of technical experience and regardless of any non-technical
+personal characteristic or identity trait (gender, religion, physicality, age, ethnicity,
+essentially **any**).
+
+Nurturing open and unemotional code reviews and community discussions, we aim at ensuring
+fruitful and enriching collaboration experience and maintaining quality engineering
+standards. This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Examples of unacceptable behavior by participants include:
+
+* Breaching project security (e.g., granting GitHub access rights without ensuring
+  collaborators' consent);
+* Breaching collaborators' privacy (e.g., publishing other's private information without
+  permission);
+* Force developments (e.g., merging or releasing against expressed collaborators' comments
+  against doing it);
+* Any form of harassing language of exclusion;
+* Other unethical or unprofessional conduct (if in doubt, ask!).
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, issues, and other contributions that are not aligned to this Code of Conduct,
+or to ban temporarily or permanently any contributor for other behaviors that they deem
+inappropriate, threatening, offensive, or harmful. By adopting this Code of Conduct, project
+maintainers commit themselves to fairly, consistently and collaboratively applying these
+principles to every aspect of managing this project. 
+
+Reporting actions that are violating the hereby Code of Conduct can be done publicly on the
+project GitHub space, or if needed, can be reported directly to any of the project maintainers
+(as of the time of writing: Sylwester Arabas, Zachary D'Aquino, Jeff Curtis, Nicole Riemer, et al.).
+Maintainers are obligated to maintain confidentiality with regard to the reporter of a
+privately reported incident.


### PR DESCRIPTION
@nriemer @zdaq12 @jcurtis2 
We've received feedback to our pyOpenSci sumbissiion: https://github.com/pyOpenSci/software-submission/issues/179#issuecomment-2131067239
One of the comments relates to lack of a code of conduct statement for the project.
This PR includes a draft of it (based on the recently written numba-mpi CoC: https://github.com/numba-mpi/numba-mpi/blob/main/CODE_OF_CONDUCT.md) in which I've mentioned all our names as points of contact. 
Please provide feedback, or it it seems OK and enough, please confirm your consent by approving this PR, thanks.