### PR TITLE
Empty(ish) constructors for data structures

### DIFF
--- a/src/aero_data.hpp
+++ b/src/aero_data.hpp
@@ -48,6 +48,11 @@ struct AeroData {
         f_aero_data_from_json(this->ptr.f_arg());
     }
 
+    AeroData() :
+        ptr(f_aero_data_ctor, f_aero_data_dtor)
+    {
+    }
+
     static auto spec_by_name(const AeroData &self, const std::string &name) {
         int value;
         const int name_size = name.size();

--- a/src/aero_state.hpp
+++ b/src/aero_state.hpp
@@ -260,6 +260,14 @@ struct AeroState {
         );
     }
 
+    AeroState(
+        std::shared_ptr<AeroData> aero_data
+    ):
+        ptr(f_aero_state_ctor, f_aero_state_dtor),
+        aero_data(aero_data)
+    {
+    }
+
     static std::size_t __len__(const AeroState &self) {
         int len;
         f_aero_state_len(

--- a/src/env_state.hpp
+++ b/src/env_state.hpp
@@ -34,6 +34,11 @@ struct EnvState {
         f_env_state_from_json(this->ptr.f_arg());
     }
 
+    EnvState() :
+        ptr(f_env_state_ctor, f_env_state_dtor)
+    {
+    }
+
     static void set_temperature(const EnvState &self, double &temperature) {
         f_env_state_set_temperature(
             self.ptr.f_arg(),

--- a/src/gas_data.hpp
+++ b/src/gas_data.hpp
@@ -41,6 +41,11 @@ struct GasData {
         f_gas_data_from_json(this->ptr.f_arg());
     }
 
+    GasData() :
+        ptr(f_gas_data_ctor, f_gas_data_dtor)
+    {
+    }
+
     static auto __str__(const GasData &self) {
         return self.json.dump();
     }   

--- a/src/pypartmc.cpp
+++ b/src/pypartmc.cpp
@@ -83,6 +83,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         )pbdoc"
     )
         .def(py::init<const nlohmann::json&>())
+        .def(py::init<>(), "Empty constructor for reading from file.")
         .def("spec_by_name", AeroData::spec_by_name,
              "Returns the number of the species in AeroData with the given name")
         .def("__len__", AeroData::__len__, "Number of aerosol species")
@@ -207,6 +208,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         )pbdoc"
     )
         .def(py::init<std::shared_ptr<AeroData>, const double, const std::string>())
+        .def(py::init<std::shared_ptr<AeroData>>(), "Empty constructor for reading from file.")
         .def("__len__", AeroState::__len__,
             "returns current number of particles")
         .def_property_readonly("total_num_conc", AeroState::total_num_conc,
@@ -286,6 +288,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         )pbdoc"
     )
         .def(py::init<const py::tuple&>())
+        .def(py::init<>(), "Empty constructor for reading from file.")
         .def("__len__", GasData::__len__,
             "returns number of gas species")
         .def_property_readonly("n_spec", GasData::__len__)
@@ -308,6 +311,7 @@ PYBIND11_MODULE(_PyPartMC, m) {
         )pbdoc"
     )
         .def(py::init<const nlohmann::json&>())
+        .def(py::init<>(), "Empty constructor for reading from file.")
         .def("set_temperature", EnvState::set_temperature,
             "sets the temperature of the environment state")
         .def_property_readonly("temp", EnvState::temp,

--- a/tests/test_aero_data.py
+++ b/tests/test_aero_data.py
@@ -56,6 +56,16 @@ class TestAeroData:
         assert sut is not None
 
     @staticmethod
+    def test_ctor_emtpy():
+        # arrange
+
+        # act
+        sut = ppmc.AeroData()
+
+        # assert
+        assert sut is not None
+
+    @staticmethod
     def test_spec_by_name_found():
         # arrange
         sut = ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL)

--- a/tests/test_aero_state.py
+++ b/tests/test_aero_state.py
@@ -72,6 +72,17 @@ class TestAeroState:
         assert sut is not None
 
     @staticmethod
+    def test_ctor_empty():
+        # arrange
+        aero_data = ppmc.AeroData()
+
+        # act
+        sut = ppmc.AeroState(aero_data)
+
+        # assert
+        assert sut is not None
+
+    @staticmethod
     @pytest.mark.skipif(platform.machine() == "arm64", reason="TODO #348")
     def test_ctor_fails_on_unknown_weighting():
         # arrange

--- a/tests/test_env_state.py
+++ b/tests/test_env_state.py
@@ -34,6 +34,14 @@ class TestEnvState:
         assert sut is not None
 
     @staticmethod
+    def test_ctor_empty():
+        # act
+        sut = ppmc.EnvState()
+
+        # assert
+        assert sut is not None
+
+    @staticmethod
     def test_dtor():
         # arrange
         sut = ppmc.EnvState(  # pylint: disable=unused-variable

--- a/tests/test_gas_data.py
+++ b/tests/test_gas_data.py
@@ -26,6 +26,17 @@ class TestGasData:
         assert sut is not None
 
     @staticmethod
+    def test_ctor_emtpy():
+        # arrange
+        pass
+
+        # act
+        sut = ppmc.GasData()
+
+        # assert
+        assert sut is not None
+
+    @staticmethod
     def test_len():
         # arrange
         data = ("X", "Y", "Z")


### PR DESCRIPTION
Added a few options to create various structures without providing any information for construction. This is useful for when using `input_state` to read input from a output files where the user has no advanced knowledge of `AeroData`, `GasData`, etc. Previously the user would have to provide some amount of minimal information to there constructors (such as a single species to `AeroData` as done in `test_aero_data.py`, etc.).

Example for when about to call `input_state`, the following would be acceptable:

```
gas_data = ppmc.GasData()
aero_data = ppmc.AeroData()
gas_state = ppmc.GasState(gas_data)
aero_state = ppmc.AeroState(aero_data)
```

Rather than some minimal information (that would actually be overwritten by `input_state`):

```
gas_data = ppmc.GasData(("SO2",))
aero_data = ppmc.AeroData(({"H2O": [1000 * si.kg / si.m**3, 1, 18e-3 * si.kg / si.mol, 0]}))
gas_state = ppmc.GasState(gas_data)
aero_state = ppmc.AeroState(aero_data, n_part, "nummass_source")
```