### PR TITLE
bump pybind11_json to 0.2.15 and remove one test skip given a segfault was fixed. closes #319

### DIFF
--- a/tests/test_aero_mode.py
+++ b/tests/test_aero_mode.py
@@ -291,16 +291,20 @@ class TestAeroMode:
         assert str(exc_info.value) == "mass_frac keys must be unique"
 
     @staticmethod
-    def test_segfault_case():  # TODO #319
-        pytest.skip()
-
+    def test_fixed_segfault_case_on_circular_reference():
+        # arrange
         aero_data = ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL)
         fishy_ctor_arg = copy.deepcopy(AERO_MODE_CTOR_LOG_NORMAL)
         fishy_ctor_arg["test_mode"]["mass_frac"].append(
             fishy_ctor_arg["test_mode"]["mass_frac"]
         )
-        print(fishy_ctor_arg)
-        ppmc.AeroMode(aero_data, fishy_ctor_arg)
+
+        # act
+        with pytest.raises(TypeError) as exc_info:
+            ppmc.AeroMode(aero_data, fishy_ctor_arg)
+
+        # assert
+        assert "incompatible constructor arguments" in str(exc_info.value)
 
     @staticmethod
     @pytest.mark.skipif(platform.machine() == "arm64", reason="TODO #348")


### PR DESCRIPTION
fixed upstream in https://github.com/pybind/pybind11_json/pull/74, thank you @dbaston