### PR TITLE
Fix possible truncation of particle optical properties values

### DIFF
--- a/src/aero_particle.hpp
+++ b/src/aero_particle.hpp
@@ -207,36 +207,18 @@ struct AeroParticle {
     }
 
     static auto scatter_cross_sect(const AeroParticle &self) {
-        int len = n_swbands;
-        double val;
-        f_aero_particle_scatter_cross_sect(
-            self.ptr.f_arg(),
-            &val,
-            &len
-        );
-        return val;
+        auto fn = f_aero_particle_scatter_cross_sect;
+        return pypartmc::get_array_values_set_len(self, fn, n_swbands);
     }
 
     static auto absorb_cross_sect(const AeroParticle &self) {
-        int len = n_swbands;
-        double val;
-        f_aero_particle_absorb_cross_sect(
-            self.ptr.f_arg(),
-            &val,
-            &len
-        );
-        return val;
+        auto fn = f_aero_particle_absorb_cross_sect;
+        return pypartmc::get_array_values_set_len(self, fn, n_swbands);
     }
 
     static auto asymmetry(const AeroParticle &self) {
-        int len = n_swbands;
-        double val;
-        f_aero_particle_asymmetry(
-            self.ptr.f_arg(),
-            &val,
-            &len
-        );
-        return val;
+        auto fn = f_aero_particle_asymmetry;
+        return pypartmc::get_array_values_set_len(self, fn, n_swbands);
     }
 
     static auto sources(const AeroParticle &self) {
@@ -262,25 +244,13 @@ struct AeroParticle {
     }
 
     static auto refract_shell(const AeroParticle &self) {
-        int len = n_swbands;
-        std::complex<double> refract_shell;
-        f_aero_particle_refract_shell(
-            self.ptr.f_arg(),
-            &refract_shell,
-            &len
-        );
-        return refract_shell;
+        auto fn = f_aero_particle_refract_shell;
+        return pypartmc::get_array_values_set_len<std::complex<double>>(self, fn, n_swbands);
     }
 
     static auto refract_core(const AeroParticle &self) {
-        int len = n_swbands;
-        std::complex<double> refract_core;
-        f_aero_particle_refract_core(
-            self.ptr.f_arg(),
-            &refract_core,
-            &len
-        );
-        return refract_core;
+        auto fn = f_aero_particle_refract_core;
+        return pypartmc::get_array_values_set_len<std::complex<double>>(self, fn, n_swbands);
     }
 
     static auto get_weight_class(const AeroParticle &self) {

--- a/tests/test_aero_particle.py
+++ b/tests/test_aero_particle.py
@@ -441,11 +441,12 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
         sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
 
         # act
-        value = sut.absorb_cross_sect
+        value = list(sut.absorb_cross_sect)
 
         # assert
-        assert value == 0
-        assert isinstance(value, float)
+        assert len(value) >= 1
+        assert all(v == 0 for v in value)
+        assert isinstance(value[0], float)
 
     @staticmethod
     def test_scatter_cross_sect():
@@ -453,11 +454,12 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
         sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
 
         # act
-        value = sut.scatter_cross_sect
+        value = list(sut.scatter_cross_sect)
 
         # assert
-        assert value == 0
-        assert isinstance(value, float)
+        assert len(value) >= 1
+        assert all(v == 0 for v in value)
+        assert isinstance(value[0], float)
 
     @staticmethod
     def test_asymmetry():
@@ -465,11 +467,12 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
         sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
 
         # act
-        value = sut.asymmetry
+        value = list(sut.asymmetry)
 
         # assert
-        assert value == 0
-        assert isinstance(value, float)
+        assert len(value) >= 1
+        assert all(v == 0 for v in value)
+        assert isinstance(value[0], float)
 
     @staticmethod
     def test_refract_shell():
@@ -477,11 +480,12 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
         sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
 
         # act
-        value = sut.refract_shell
+        value = list(sut.refract_shell)
 
         # assert
-        assert value == 0 + 0j
-        assert isinstance(value, complex)
+        assert len(value) >= 1
+        assert all(v == 0 + 0j for v in value)
+        assert isinstance(value[0], complex)
 
     @staticmethod
     def test_refract_core():
@@ -489,11 +493,12 @@ class TestAeroParticle:  # pylint: disable=too-many-public-methods
         sut = ppmc.AeroParticle(ppmc.AeroData(AERO_DATA_CTOR_ARG_MINIMAL), [44])
 
         # act
-        value = sut.refract_core
+        value = list(sut.refract_core)
 
         # assert
-        assert value == 0 + 0j
-        assert isinstance(value, complex)
+        assert len(value) >= 1
+        assert all(v == 0 + 0j for v in value)
+        assert isinstance(value[0], complex)
 
     @staticmethod
     def test_sources():


### PR DESCRIPTION
Fixes #469. Particle optical properties were returning a scalar value when the fortran code was fetching and returning an array. Typically this of size 1 so it wasn't noticeable.

All 5 calls for particle properties now return a std::valarray of the correct type (either real or complex) using the templates for arrays. Tests were expanded to operate to handle the possibility of multiple wavelengths.